### PR TITLE
Fix sighting by UUID

### DIFF
--- a/misp42splunk/bin/misp_alert_sighting.py
+++ b/misp42splunk/bin/misp_alert_sighting.py
@@ -173,6 +173,7 @@ def create_alert(config, results):
             if 'uuid' in row:
                 value = row['uuid']
                 if value != "":
+                    value = value.splitlines()[0]
                     sightings[value] = timestamp
 
     # set proper headers
@@ -191,7 +192,7 @@ def create_alert(config, results):
         else:
             sighting = json.dumps(dict(
                 timestamp=int(data),
-                id=key,
+                uuid=key,
                 type=sighting_type
             ))
 


### PR DESCRIPTION
This patch fixes `misp_alert_sighting.py`
* The attribute UUID should be submitted not the attribute ID
* When a MISP IOC is hit twice, splunk makes the uuid field multi-value. I did added a quick fix to make the alert still work. Example:
```
'uuid': '5ca5f396-b6a8-439f-9373-5e3a95d2dbc0\n5ca5f396-b6a8-439f-9373-5e3a95d2dbc0'
```
I tested this with the following search:
```
sourcetype="tinyproxy*" CONNECT | rex "CONNECT.* (GET|POST) (?P<url>[^ ]+)"  | rex field=url "\:\/\/(?<dest_host>[^\/]+)"  | rex "CONNECT.* Established connection to host \"(?P<dest_host>[^\"]+)" | lookup MISP_web misp_domain AS dest_host OUTPUT misp_attribute_uuid AS uuid | where isnotnull(uuid)
```