### PR TITLE
Added full support for python request verify. 

### DIFF
--- a/misp42splunk/README/inputs.conf.spec
+++ b/misp42splunk/README/inputs.conf.spec
@@ -2,6 +2,7 @@
 misp_url = provide MISP URL. Do not end with a /
 misp_key = provide one authkey for the instance
 misp_verifycert = 
+misp_ca_full_path = Provide full path to CA file (pem, crt)
 misp_use_proxy = Use proxy settings for default instance
 client_use_cert = Use a client certificate to authenticate on default instance
 client_cert_full_path = Provide full path to client certificate file

--- a/misp42splunk/appserver/static/js/build/globalConfig.json
+++ b/misp42splunk/appserver/static/js/build/globalConfig.json
@@ -253,7 +253,10 @@
                     {
                         "field": "misp_verifycert", 
                         "label": "Check MISP certificate"
-                    }, 
+                    },
+                    {   "field": "misp_ca_full_path",
+                        "label": "MISP CA path"
+                    },
                     {
                         "field": "misp_use_proxy", 
                         "label": "Use proxy settings"
@@ -396,6 +399,21 @@
                             "help": "", 
                             "type": "checkbox"
                         }, 
+                        {
+                            "required": false,
+                            "label": "MISP CA path",
+                            "field": "misp_ca_full_path",
+                            "validators": [
+                                {
+                                    "minLength": 0,
+                                    "errorMsg": "Max length of text input is 8192",
+                                    "maxLength": 8192,
+                                    "type": "string"
+                                }
+                            ],
+                            "help": "Provide full path to CA file (pem, crt)",
+                            "type": "text"
+                        },
                         {
                             "required": false, 
                             "field": "misp_use_proxy", 

--- a/misp42splunk/bin/misp.py
+++ b/misp42splunk/bin/misp.py
@@ -58,6 +58,10 @@ class ModInputmisp(modinput_wrapper.base_modinput.BaseModInput):
                                          description="",
                                          required_on_create=False,
                                          required_on_edit=False))
+        scheme.add_argument(smi.Argument("misp_ca_full_path", title="MISP CA path",
+                                         description="Provide full path to CA file (pem, crt)",
+                                         required_on_create=False,
+                                         required_on_edit=False))
         scheme.add_argument(smi.Argument("misp_use_proxy", title="Use proxy settings",
                                          description="Use proxy settings for default instance",
                                          required_on_create=False,

--- a/misp42splunk/bin/misp42splunk_rh_misp.py
+++ b/misp42splunk/bin/misp42splunk_rh_misp.py
@@ -61,6 +61,16 @@ fields = [
         validator=None
     ), 
     field.RestField(
+        'misp_ca_full_path',
+        required=False,
+        encrypted=False,
+        default=None,
+        validator=validator.String(
+            max_len=8192,
+            min_len=0,
+        )
+    ),
+    field.RestField(
         'misp_use_proxy',
         required=False,
         encrypted=False,

--- a/misp42splunk/bin/misp_common.py
+++ b/misp42splunk/bin/misp_common.py
@@ -64,7 +64,14 @@ def prepare_config(self):
         config_args['misp_verifycert'] = True
     else:
         config_args['misp_verifycert'] = False
+
+    if config_args['misp_verifycert']:
+        misp_ca_full_path = mispconf.get('misp_ca_full_path', '')
+        if misp_ca_full_path != '':
+            config_args['misp_verifycert'] = misp_ca_full_path
     logging.info("config_args['misp_verifycert'] {}".format(config_args['misp_verifycert']))
+    logging.info("config_args['misp_ca_full_path'] {}".format(config_args['misp_ca_full_path']))
+
     config_args['proxies'] = dict()
     if int(mispconf['misp_use_proxy']) == 1:
         settings_file = _SPLUNK_PATH + os.sep + 'etc' + os.sep + 'apps' \


### PR DESCRIPTION
Python request verify supports three states: true, false and a path to certificate file. I needed to set a specific path. I tried to manually edit inputs.conf after setup and changing misp_verifycert to a path. But there is an input check on this field to check if it's a number and if it's not then it throws an exception. So I started editing the code to make it work and by the time I was done it seems that this might be something that others might like to use as well.