### PR TITLE
BUG - Numeric values for event analysis configurations are off by 1

### DIFF
--- a/misp42splunk/default/data/ui/alerts/misp_alert_create_event.html
+++ b/misp42splunk/default/data/ui/alerts/misp_alert_create_event.html
@@ -85,9 +85,9 @@
 	<label class="control-label" for="misp_alert_create_event_analysis">Analysis <span class="required">*</span> </label>
     <div class="controls">
 <select name="action.misp_alert_create_event.param.analysis" id="misp_alert_create_event_analysis">
-        <option value="2">Ongoing</option>
-        <option value="3">Complete</option>
-        <option value="1">Initial</option>
+        <option value="1">Ongoing</option>
+        <option value="2">Complete</option>
+        <option value="0">Initial</option>
 </select>
                 <span class="help-block"> 
                     Change Analysis status. Default to Initial


### PR DESCRIPTION
Update misp_alert_create_event.html
action.misp_alert_create_event.param.analysis values are off by 1, allowed values are 0-2