### PR TITLE
Add new mispgetattribute command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ you can also use this example (thanks @xg-simon for sharing):
     * [mispcollect](docs/mispcollect.md) Generating command for events leveraging /attributes/restSearch or /events/restSearch endpoints
     * [misprest](https://github.com/remg427/misp42splunk/blob/master/docs/misprest.md) Generating command as a wrapper for MISP REST API.
     * [mispsearch](https://github.com/remg427/misp42splunk/blob/master/docs/mispsearch.md) streaming command
+    * [mispgetattribute](https://github.com/remg427/misp42splunk/blob/master/docs/mispgetattribute.md) Streaming command for getting a single attribute
     * [mispsight](docs/mispsight.md) streaming command
 - Splunk alert actions to [update MISP](https://github.com/remg427/misp42splunk/blob/master/docs/mispalerts.md)
     *  Alert to create MISP event(s) with an option to publish them at same time.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This app is designed to run on **Splunk Search Head(s)** on Linux plateforms (no
     - check (or not) the certificate of the MISP server,
     - use (or not) the proxy for this instance,
     - provide client certificate if required (and check the box to use it)
-![inputs](https://github.com/remg427/misp42splunk/blob/master/images/misp42_add_misp_instance.png)
+![inputs](https://github.com/remg427/misp42splunk/blob/main/images/misp42_add_misp_instance.png)
 6. If you need **several instances**, create additional entries.
 7. Important: Role(s)/user(s) using this app must have the capability to "list_storage_passwords" (as API KEYs and proxy password(s) are safely stored encrypted).
 
@@ -79,22 +79,22 @@ you can also use this example (thanks @xg-simon for sharing):
 
 ## Usage
 - custom commands
-    * [mispgetioc](https://github.com/remg427/misp42splunk/blob/master/docs/mispgetioc.md) Generating command leveraging /attributes/restSearch endpoint
-    * [mispgetevent](https://github.com/remg427/misp42splunk/blob/master/docs/mispgetevent.md) Generating command leveraging /events/restSearch endpoint
+    * [mispgetioc](https://github.com/remg427/misp42splunk/blob/main/docs/mispgetioc.md) Generating command leveraging /attributes/restSearch endpoint
+    * [mispgetevent](https://github.com/remg427/misp42splunk/blob/main/docs/mispgetevent.md) Generating command leveraging /events/restSearch endpoint
     * [mispcollect](docs/mispcollect.md) Generating command for events leveraging /attributes/restSearch or /events/restSearch endpoints
-    * [misprest](https://github.com/remg427/misp42splunk/blob/master/docs/misprest.md) Generating command as a wrapper for MISP REST API.
-    * [mispsearch](https://github.com/remg427/misp42splunk/blob/master/docs/mispsearch.md) streaming command
-    * [mispgetattribute](https://github.com/remg427/misp42splunk/blob/master/docs/mispgetattribute.md) Streaming command for getting a single attribute
+    * [misprest](https://github.com/remg427/misp42splunk/blob/main/docs/misprest.md) Generating command as a wrapper for MISP REST API.
+    * [mispsearch](https://github.com/remg427/misp42splunk/blob/main/docs/mispsearch.md) streaming command
+    * [mispgetattribute](https://github.com/remg427/misp42splunk/blob/main/docs/mispgetattribute.md) Streaming command for getting a single attribute
     * [mispsight](docs/mispsight.md) streaming command
-- Splunk alert actions to [update MISP](https://github.com/remg427/misp42splunk/blob/master/docs/mispalerts.md)
+- Splunk alert actions to [update MISP](https://github.com/remg427/misp42splunk/blob/main/docs/mispalerts.md)
     *  Alert to create MISP event(s) with an option to publish them at same time.
     *  Alert for attribute sighting in MISP.  
    
 - Each custome command and alert action comes with a dashboard to demonstrate how to use them.
-    * mispgetioc for example for a generating command (first line of SPL) ![mispgetioc](https://github.com/remg427/misp42splunk/blob/master/images/misp42_custom_command_mispgetioc_dashboard.png) 
-    * mispsearch for example for a streaming command to enrich events ![mispsearch](https://github.com/remg427/misp42splunk/blob/master/images/misp42_custom_command_mispsearch_dashboard.png) 
-    * misprest for example for the more versdatile wrapper of MISP API ![misprest](https://github.com/remg427/misp42splunk/blob/master/images/misp42_custom_command_misprest_dashboard.png) 
-    * Create event for example for an alert action ![misp_alert_create_evennt](https://github.com/remg427/misp42splunk/blob/master/images/misp42_alert_action_create_event_dashboard.png) 
+    * mispgetioc for example for a generating command (first line of SPL) ![mispgetioc](https://github.com/remg427/misp42splunk/blob/main/images/misp42_custom_command_mispgetioc_dashboard.png) 
+    * mispsearch for example for a streaming command to enrich events ![mispsearch](https://github.com/remg427/misp42splunk/blob/main/images/misp42_custom_command_mispsearch_dashboard.png) 
+    * misprest for example for the more versdatile wrapper of MISP API ![misprest](https://github.com/remg427/misp42splunk/blob/main/images/misp42_custom_command_misprest_dashboard.png) 
+    * Create event for example for an alert action ![misp_alert_create_evennt](https://github.com/remg427/misp42splunk/blob/main/images/misp42_alert_action_create_event_dashboard.png) 
 
 ## Credits
 The creation of this app started from work done by https://github.com/xme/splunk/tree/master/getmispioc and the associated blog https://blog.rootshell.be/2017/10/31/splunk-custom-search-command-searching-misp-iocs/ for MISP interactions.

--- a/docs/mispgetattribute.md
+++ b/docs/mispgetattribute.md
@@ -1,0 +1,58 @@
+# mispgetattribute
+
+## Description
+The `mispgetattribute` command retrieves a single attribute from a MISP instance based on a given ID.
+
+## Syntax
+```spl
+| mispgetattribute misp_instance=<string>
+[attributeid=<id>] [fields=<field1,field2,...>] [prefix=<string>]
+```
+
+## Parameters
+### Required Parameters
+- **misp_instance**
+  - **Syntax:** `misp_instance=<string>`
+  - **Description:** Specifies the MISP instance to use. The configuration must be defined in `local/misp42splunk_instances.conf`.
+
+### Optional Parameters
+- **attributeid**
+  - **Syntax:** `attributeid=<id>`
+  - **Description:** The ID of the attribute. Can also be passed as defined field in each row.
+
+- **fields**
+  - **Syntax:** `fields=<field1,field2,...>`
+  - **Description:** A comma-sepearted list of field names that should be returned. Leave the field empty to return all.
+
+- **prefix**
+  - **Syntax:** `prefix=<string>`
+  - **Description:** Prefix for the returned field names.
+
+## Examples
+
+### Retrieve all attribute fields by attribute ID
+```spl
+| makeresults
+| mispgetattribute misp_instance=default_misp attributeid=1234
+```
+
+### Retrieve specified attribute fields by attribute ID with prefix
+```spl
+| makeresults
+| mispgetattribute misp_instance=default_misp attributeid=1234 fields=id,uuid,event_id,deleted prefix=attr_
+```
+
+### Retrieve all attribute fields by attribute ID in field
+```spl
+| makeresults
+| eval attributeid=1234
+| mispgetattribute misp_instance=default_misp
+```
+
+## Logging
+Logs are written to `misp42splunk.log` and can be accessed via the Splunk job inspector. You can configure the logging level for detailed debugging information.
+
+## Version
+- **Current Version:** 5.0.0
+- **Authors:** Remi Seguy, timothebot
+- **License:** LGPLv3

--- a/package/bin/mispgetattribute.py
+++ b/package/bin/mispgetattribute.py
@@ -1,0 +1,121 @@
+# coding=utf-8
+#
+# Extract IOC's from MISP
+#
+# Author: Remi Seguy <remg427@gmail.com>
+#
+# Copyright: LGPLv3 (https://www.gnu.org/licenses/lgpl-3.0.txt)
+# Feel free to use the code, but please share the changes you've made
+#
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+import json
+import misp42splunk_declare
+from splunklib.searchcommands import dispatch, StreamingCommand, Configuration, Option, validators
+import sys
+import logging
+from misp_common import prepare_config, urllib_request, logging_level, urllib_init_pool
+
+__author__ = "Remi Seguy"
+__license__ = "LGPLv3"
+__version__ = "5.0.0"
+__maintainer__ = "Remi Seguy"
+__email__ = "remg427@gmail.com"
+
+
+@Configuration(distributed=False)
+class MispGetAttributeCommand(StreamingCommand):
+    misp_instance = Option(
+        doc='''
+        **Syntax:** **misp_instance=** *instance_name*
+        **Description:** MISP instance parameters as described in local/misp42splunk_instances.conf.
+        ''',
+        require=True
+    )
+    attributeid = Option(
+        doc='''
+        **Syntax:** **attributeid=** *id*
+        **Description:** ID of attribute to check
+        ''',
+        require=False
+    )
+    fields = Option(
+        doc='''
+        **Syntax:** **fields=** *CSV string*
+        **Description:** comma(,)-separated string of fields to use. Default is all fields.
+        ''',
+        require=False
+    )
+    prefix = Option(
+        doc='''
+        **Syntax:** **prefix=** *<string>*
+        **Description:** string to use as prefix for misp keys
+        ''',
+        require=False, 
+        validate=validators.Match("prefix", r"^[a-zA-Z][a-zA-Z0-9_]+$")
+    )
+
+    def log_error(self, msg):
+        logging.error(msg)
+
+    def log_info(self, msg):
+        logging.info(msg)
+
+    def log_debug(self, msg):
+        logging.debug(msg)
+
+    def log_warn(self, msg):
+        logging.warning(msg)
+
+    def set_log_level(self):
+        logging.root
+        loglevel = logging_level('misp42splunk')
+        logging.root.setLevel(loglevel)
+        logging.error('[EV-101] logging level is set to %s', loglevel)
+        logging.error('[EV-102] PYTHON VERSION: ' + sys.version)
+
+    def stream(self, records):
+        self.set_log_level()
+        misp_instance = self.misp_instance
+        storage = self.service.storage_passwords
+        config = prepare_config(self, 'misp42splunk', misp_instance, storage)
+        if config is None:
+            raise Exception(
+                "[EV-101] Sorry, no configuration for misp_instance={}".format(misp_instance))
+        base_url = config['misp_url'] + "/attributes/view/"
+        
+        shown_fields = []
+        if self.fields:
+            shown_fields = self.fields.replace(" ", "").split(",")
+        filter_fields = len(shown_fields) > 0
+
+        for record in records:
+            if self.attributeid:
+                attribute_id = self.attributeid
+            elif "attributeid" in record:
+                attribute_id = record["attributeid"]
+            else:
+                raise Exception("[AT-101] No attributeid found!")
+            
+            config['misp_url'] = base_url + str(attribute_id)
+
+            connection, connection_status = urllib_init_pool(self, config)
+            if connection is None:
+                response = connection_status
+                self.log_info('[AT-102] connection for {} failed'.format(config['misp_url']))
+                yield record
+                continue
+            
+            response = urllib_request(self, connection, "GET", config['misp_url'], {}, config)
+            if "Attribute" in response:
+                attribute_fields = response["Attribute"]
+                for field_key in attribute_fields:
+                    if filter_fields and field_key not in shown_fields:
+                        continue
+                    prefix = self.prefix if self.prefix else ""
+                    record[prefix + field_key] = response["Attribute"][field_key]
+
+            yield record
+
+if __name__ == "__main__":
+    dispatch(MispGetAttributeCommand, sys.argv, sys.stdin, sys.stdout, __name__)

--- a/package/default/commands.conf
+++ b/package/default/commands.conf
@@ -22,3 +22,8 @@ chunked = true
 python.version = python
 filename = misprest.py
 chunked = true
+
+[mispgetattribute]
+python.version = python
+filename = mispgetattribute.py
+chunked = true

--- a/package/default/data/ui/nav/default.xml
+++ b/package/default/data/ui/nav/default.xml
@@ -5,6 +5,7 @@
 		<view name="mispgetioc" label="Get MISP attributes"/>
       	<view name="mispgetevent" label="Get MISP events"/>
 		<view name="mispsearch" label="Search MISP for matching attributes"/>
+		<view name="mispgetattribute" label="Get a MISP event attribute by ID"/>
       	<view name="misprest" label="MISP REST wrapper"/>
 	</collection>
 	<collection label="MISP alert actions">

--- a/package/default/data/ui/views/mispgetattribute.xml
+++ b/package/default/data/ui/views/mispgetattribute.xml
@@ -1,0 +1,68 @@
+<form hideEdit="false" version="1.1">
+  <init>
+    <set token="misp_json_request"></set>
+  </init>
+  <label>mispgetattribute</label>
+  <description>MISP custom command misprest - Generic wrapper (Generating command) - check https://github.com/remg427/misp42splunk/ for any update</description>
+  <fieldset submitButton="false">
+    <input type="dropdown" token="misp_instance" searchWhenChanged="true">
+      <label>misp_instance*</label>
+      <fieldForLabel>misp_instance</fieldForLabel>
+      <fieldForValue>misp_instance</fieldForValue>
+      <search>
+        <query>| rest /services/configs/conf-misp42splunk_instances
+| rename eai:acl.app as app, title as misp_instance
+| fields misp_instance</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
+    <input type="text" token="misp_instance">
+      <label>misp_instance*</label>
+    </input>
+    <input type="text" token="attributeid" searchWhenChanged="true">
+      <label>attributeid</label>
+      <default></default>
+    </input>
+    <input type="text" token="fields" searchWhenChanged="true">
+      <label>fields</label>
+      <default></default>
+    </input>
+    <input type="text" token="prefix" searchWhenChanged="true">
+      <label>prefix</label>
+    </input>
+  </fieldset>
+  <row>
+    <panel>
+      <html>
+        <h3>Select a misp_instance and provide a valid attributeid.</h3>
+        <p>attributeid can also be a field in the row.</p>
+        <p>Specify which fields should be returned, else all are returned.</p>
+    </html>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <title>Custom command mispgetattribute</title>
+      <event>
+        <search>
+          <query>| makeresults | mispgetattribute misp_instance=$misp_instance$ attributeid=$attributeid$ fields=$fields$ prefix=$prefix$</query>
+          <earliest>0</earliest>
+          <latest></latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="count">5</option>
+        <option name="list.drilldown">none</option>
+        <option name="list.wrap">1</option>
+        <option name="maxLines">5</option>
+        <option name="raw.drilldown">full</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="rowNumbers">0</option>
+        <option name="table.drilldown">all</option>
+        <option name="table.sortDirection">asc</option>
+        <option name="table.wrap">1</option>
+        <option name="type">list</option>
+      </event>
+    </panel>
+  </row>
+</form>

--- a/package/default/searchbnf.conf
+++ b/package/default/searchbnf.conf
@@ -113,3 +113,21 @@ tags = misp
 
 [misprest-options]
 syntax = misp_instance=<string> method=<string> target=<string> json_request=<string>
+
+##################
+# mispgetattribute
+##################
+[mispgetattribute-command]
+syntax = | mispgetattribute <mispgetattribute-options>
+shortdesc = Retrieve a single attribute by ID
+description = mispgetattribute returns a single attribute record if it exists.
+usage=public
+example1 = | mispgetattribute misp_instance=misp attributeid=1234
+comment1 = Returns all fields of the attribute with id 1234
+example2 = | eval attributeid=1234 | mispgetattribute misp_instance=misp fields=event_id,deleted
+comment2 = Returns field event_id and deleted of the attribute with id 1234
+related = misp
+tags = misp
+
+[mispgetattribute-options]
+syntax = misp_instance=<string> attributeid=<id> prefix=<string> fields=<field1,field2,...>


### PR DESCRIPTION
This command is useful if you want to fetch a single attribute
(/attributes/view/<id>) with a streaming command.
This allows you for example to verify that a single attribute is still
valid instead of having to check all of them. In case that an attribute
is hard deleted and not set to deleted=true properly, you can use this
command to figure that out.

The other commands have similar functionality, but are non streaming
commands.

I also updated the docs, including creating a new dashboard and linking it in the nav.


If you'd merge this, a new version 5.1.0 release would be appreciated! Thanks for your time!